### PR TITLE
Drop Minimum OS

### DIFF
--- a/SpatialVideoGist/SpatialVideoGist.xcodeproj/project.pbxproj
+++ b/SpatialVideoGist/SpatialVideoGist.xcodeproj/project.pbxproj
@@ -330,7 +330,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 14.2;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bbl11.SpatialVideoGist;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -367,7 +367,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 14.2;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bbl11.SpatialVideoGist;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Drops the minimum OS version to macOS 14 from macOS 14.2 as there are no changes in macOS 14.2 necessary to support this app's functionality.